### PR TITLE
HFP-3758 Fix row break application on resize

### DIFF
--- a/memory-game.js
+++ b/memory-game.js
@@ -554,9 +554,7 @@ H5P.MemoryGame = (function (EventDispatcher, $) {
         // want things sticking out…)
         var colSize = Math.floor((100 / numCols) * 10000) / 10000;
         $elements.css('width', colSize + '%').each(function (i, e) {
-          if (i === numCols) {
-            $(e).addClass('h5p-row-break');
-          }
+          $(e).toggleClass('h5p-row-break', i === numCols);
         });
       }
 


### PR DESCRIPTION
Currently, when sizing the Memory Game container down and back up again while trying to create a square shape, the application of the row-break fails. It can be applied to a column with a lower index as the width shrinks, but it is never removed when the width grows again leading to wrong breaks.

When merged in, will set the row-break to the outer right column but remove it from all the others to fix this.