### PR TITLE
JI-5657 Only reset if attached

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "See how many cards you can remember!",
   "majorVersion": 1,
   "minorVersion": 3,
-  "patchVersion": 15,
+  "patchVersion": 16,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",

--- a/memory-game.js
+++ b/memory-game.js
@@ -517,6 +517,8 @@ H5P.MemoryGame = (function (EventDispatcher, $) {
 
         $list.appendTo($container);
       }
+
+      self.attached = true;
     };
 
     /**
@@ -673,8 +675,10 @@ H5P.MemoryGame = (function (EventDispatcher, $) {
      * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-5}
      */
     self.resetTask = function () {
-      removeRetryButton();
-      resetGame();
+      if (self.attached) {
+        removeRetryButton();
+        resetGame();
+      }
     };
   }
 


### PR DESCRIPTION
This ensures there is no error when resetTask is called on an instance of Memory Game that has not yet been attached. Since the library doesn't implement resume itself, this should be sufficient.