### PR TITLE
Fix label instructions

### DIFF
--- a/memory-game.css
+++ b/memory-game.css
@@ -4,7 +4,7 @@
 .h5p-memory-game .h5p-memory-hidden-read {
   position: absolute;
   top: -1px;
-  left: -1px;
+  left: -99999px;
   width: 1px;
   height: 1px;
   color: transparent;

--- a/semantics.json
+++ b/semantics.json
@@ -202,7 +202,7 @@
       {
         "label": "Game instructions",
         "importance": "low",
-        "name": "label",
+        "name": "labelInstructions",
         "type": "text",
         "default": "Use arrow keys left and right to navigate cards. Use space or enter key to turn card."
       },


### PR DESCRIPTION
When merged in, will render the `labelInstructions` for a11y offsite, so the user cannot "see" the hidden read when (accidentally) highlighting text.