### PR TITLE
Add support for enableRetry override

### DIFF
--- a/src/scripts/memory-game.js
+++ b/src/scripts/memory-game.js
@@ -129,7 +129,11 @@ H5P.MemoryGame = (function (EventDispatcher, $) {
       }
       score = 1;
 
-      if (parameters.behaviour && parameters.behaviour.allowRetry) {
+      const isRetryAllowed = typeof parameters.behaviour?.enableRetry === 'boolean' ?
+        parameters.behaviour?.enableRetry :
+        parameters.behaviour?.allowRetry;
+
+      if (isRetryAllowed) {
         // Create retry button
         self.retryButton = H5P.Components.Button({
           label: parameters.l10n.tryAgain || 'Reset',


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Feature

**What is the current behaviour?**
An author can set whether the retry button should be available when the user finished. There is no way, however, for parent content types to override that setting (as e.g. QuestionSet could and does for other content types).

**What is the new behaviour?**
Parent content types can override the availability of the retry button by setting `enableRetry` on the `behaviour` parameters as defined in H5P Groups's own Question Type contract at https://h5p.org/documentation/developers/contracts#guides-header-10

It would have been possible to rename the option in semantics directly, but then the minor version would have to be bumped + an upgrade script added. Wanted to keep it simple, but this can be changed as well if requested.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
